### PR TITLE
[WIP] Release of v1.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1,10 +1,125 @@
 [[package]]
+category = "dev"
+description = "Atomic file writes."
+marker = "sys_platform == \"win32\""
+name = "atomicwrites"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.4.0"
+
+[[package]]
+category = "dev"
+description = "Classes Without Boilerplate"
+name = "attrs"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "19.3.0"
+
+[package.extras]
+azure-pipelines = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "pytest-azurepipelines"]
+dev = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "pre-commit"]
+docs = ["sphinx", "zope.interface"]
+tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+
+[[package]]
+category = "dev"
+description = "Cross-platform colored terminal text."
+marker = "sys_platform == \"win32\""
+name = "colorama"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.4.3"
+
+[[package]]
+category = "dev"
+description = "More routines for operating on iterables, beyond itertools"
+name = "more-itertools"
+optional = false
+python-versions = ">=3.5"
+version = "8.3.0"
+
+[[package]]
 category = "main"
 description = "NumPy is the fundamental package for array computing with Python."
 name = "numpy"
 optional = false
 python-versions = ">=3.5"
 version = "1.18.4"
+
+[[package]]
+category = "dev"
+description = "Core utilities for Python packages"
+name = "packaging"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "20.4"
+
+[package.dependencies]
+pyparsing = ">=2.0.2"
+six = "*"
+
+[[package]]
+category = "dev"
+description = "plugin and hook calling mechanisms for python"
+name = "pluggy"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.13.1"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+
+[[package]]
+category = "dev"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+name = "py"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.8.1"
+
+[[package]]
+category = "dev"
+description = "Python parsing module"
+name = "pyparsing"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "2.4.7"
+
+[[package]]
+category = "dev"
+description = "pytest: simple powerful testing with Python"
+name = "pytest"
+optional = false
+python-versions = ">=3.5"
+version = "5.4.3"
+
+[package.dependencies]
+atomicwrites = ">=1.0"
+attrs = ">=17.4.0"
+colorama = "*"
+more-itertools = ">=4.0.0"
+packaging = "*"
+pluggy = ">=0.12,<1.0"
+py = ">=1.5.0"
+wcwidth = "*"
+
+[package.extras]
+checkqa-mypy = ["mypy (v0.761)"]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
+[[package]]
+category = "dev"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+name = "pytest-mock"
+optional = false
+python-versions = ">=3.5"
+version = "3.1.1"
+
+[package.dependencies]
+pytest = ">=2.7"
+
+[package.extras]
+dev = ["pre-commit", "tox", "pytest-asyncio"]
 
 [[package]]
 category = "main"
@@ -22,11 +137,43 @@ optional = false
 python-versions = "*"
 version = "1.0.2"
 
+[[package]]
+category = "dev"
+description = "Python 2 and 3 compatibility utilities"
+name = "six"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "1.15.0"
+
+[[package]]
+category = "dev"
+description = "Measures the displayed width of unicode strings in a terminal"
+name = "wcwidth"
+optional = false
+python-versions = "*"
+version = "0.2.3"
+
 [metadata]
-content-hash = "0a7450f2ed035d113a48329ac4d63307aab7d24a675896dcd39ef2a41ebe3bf4"
+content-hash = "c6d3c77eac54af99ab5690b39adee9f7ba0ac7766b1569afe5837c373d8408c6"
 python-versions = "^3.8"
 
 [metadata.files]
+atomicwrites = [
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+]
+attrs = [
+    {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
+    {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
+]
+colorama = [
+    {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
+    {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
+]
+more-itertools = [
+    {file = "more-itertools-8.3.0.tar.gz", hash = "sha256:558bb897a2232f5e4f8e2399089e35aecb746e1f9191b6584a151647e89267be"},
+    {file = "more_itertools-8.3.0-py3-none-any.whl", hash = "sha256:7818f596b1e87be009031c7653d01acc46ed422e6656b394b0f765ce66ed4982"},
+]
 numpy = [
     {file = "numpy-1.18.4-cp35-cp35m-macosx_10_9_intel.whl", hash = "sha256:efdba339fffb0e80fcc19524e4fdbda2e2b5772ea46720c44eaac28096d60720"},
     {file = "numpy-1.18.4-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2b573fcf6f9863ce746e4ad00ac18a948978bb3781cffa4305134d31801f3e26"},
@@ -50,6 +197,30 @@ numpy = [
     {file = "numpy-1.18.4-cp38-cp38-win_amd64.whl", hash = "sha256:1be2e96314a66f5f1ce7764274327fd4fb9da58584eaff00b5a5221edefee7d6"},
     {file = "numpy-1.18.4.zip", hash = "sha256:bbcc85aaf4cd84ba057decaead058f43191cc0e30d6bc5d44fe336dc3d3f4509"},
 ]
+packaging = [
+    {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
+    {file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8"},
+]
+pluggy = [
+    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
+    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+]
+py = [
+    {file = "py-1.8.1-py2.py3-none-any.whl", hash = "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"},
+    {file = "py-1.8.1.tar.gz", hash = "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa"},
+]
+pyparsing = [
+    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
+    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
+]
+pytest = [
+    {file = "pytest-5.4.3-py3-none-any.whl", hash = "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1"},
+    {file = "pytest-5.4.3.tar.gz", hash = "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"},
+]
+pytest-mock = [
+    {file = "pytest-mock-3.1.1.tar.gz", hash = "sha256:636e792f7dd9e2c80657e174c04bf7aa92672350090736d82e97e92ce8f68737"},
+    {file = "pytest_mock-3.1.1-py3-none-any.whl", hash = "sha256:a9fedba70e37acf016238bb2293f2652ce19985ceb245bbd3d7f3e4032667402"},
+]
 python-usbtmc = [
     {file = "python-usbtmc-0.8.tar.gz", hash = "sha256:510658781dd94a38d86c6f742a338a5a737af76c71ed15718088cbee9aeb0ba7"},
     {file = "python_usbtmc-0.8-py2.7.egg", hash = "sha256:39165d4a6faa0b2fd14ddab6818f4a5337cab804ef2000023f3d499f76ec4dc9"},
@@ -57,4 +228,12 @@ python-usbtmc = [
 ]
 pyusb = [
     {file = "pyusb-1.0.2.tar.gz", hash = "sha256:4e9b72cc4a4205ca64fbf1f3fff39a335512166c151ad103e55c8223ac147362"},
+]
+six = [
+    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
+    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+]
+wcwidth = [
+    {file = "wcwidth-0.2.3-py2.py3-none-any.whl", hash = "sha256:980fbf4f3c196c0f329cdcd1e84c554d6a211f18e252e525a0cf4223154a41d6"},
+    {file = "wcwidth-0.2.3.tar.gz", hash = "sha256:edbc2b718b4db6cdf393eefe3a420183947d6aa312505ce6754516f458ff8830"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ python-usbtmc = "^0.8"
 pyusb = "^1.0.2"
 
 [tool.poetry.dev-dependencies]
+pytest = "^5.4.3"
+pytest-mock = "^3.1.1"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/src/oscilloscopy/generator.py
+++ b/src/oscilloscopy/generator.py
@@ -22,19 +22,19 @@ class Generator:
             "WGEN:FUNC SIN;FREQ {};VOLT {};VOLT:OFFS {}".format(freq, amp, offs)
         )
 
-    def sqr(self, amp, freq, duty_cicle=50.0, offs=0.0):
+    def square(self, amp, freq, duty_cycle=50.0, offs=0.0):
         """Generates a square wave.
 
         Args:
         amp -- wave amplitude
         freq -- wave frequency
-        duty_cycle -- wave duty_cicle in % (default 50.0)
+        duty_cycle -- wave duty_cycle in % (default 50.0)
         offs -- wave offset (default 0.0)
         """
         self.on()
         self.inst.write(
             "WGEN:FUNC SQU;FREQ {};VOLT {};VOLT:OFFS {};:WGEN:FUNC:SQU:DCYC {}".format(
-                freq, amp, offs, duty_cicle
+                freq, amp, offs, duty_cycle
             )
         )
 

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest_mock import mocker
+from unittest.mock import call
 import usbtmc
 from src.oscilloscopy import channel
 
@@ -14,12 +15,24 @@ def mock_inst_ask(mocker):
     mock.return_value = 100
     return mock
 
+@pytest.fixture
+def mock_inst_ask_true(mocker):
+    mock = mocker.patch('usbtmc.Instrument.ask')
+    mock.return_value = "1"
+    return mock
+
+@pytest.fixture
+def mock_inst_ask_false(mocker):
+    mock = mocker.patch('usbtmc.Instrument.ask')
+    mock.return_value = "0"
+    return mock
+
 def test_get_time_scale(mock_inst, mock_inst_ask):
     ch = channel.Channel(mock_inst)
     result = ch.get_time_scale()
     assert result == 100 and type(result) is float
  
-def test_set_time_scale(mock_inst, mock_inst_ask):
+def test_set_time_scale(mock_inst):
     ch = channel.Channel(mock_inst)
     ch.set_time_scale(120)
     mock_inst.write.assert_called_with(':TIM:SCAL 120')
@@ -29,7 +42,84 @@ def test_get_time_delay(mock_inst, mock_inst_ask):
     result = ch.get_time_delay()
     assert result == 100.0 and type(result) is float
  
-def test_set_time_delay(mock_inst, mock_inst_ask):
+def test_set_time_delay(mock_inst):
     ch = channel.Channel(mock_inst)
     ch.set_time_delay(120)
     mock_inst.write.assert_called_with(':TIM:POS 120')
+
+def test_get_volt_scale(mock_inst, mock_inst_ask):
+    ch = channel.Channel(mock_inst)
+    result = ch.get_volt_scale(1)
+    assert result == 100.0 and type(result) is float
+
+def test_set_volt_scale(mock_inst):
+    ch = channel.Channel(mock_inst)
+    ch.set_volt_scale(1, 100)
+    mock_inst.write.assert_called_with(':CHAN1:SCAL 100')
+    
+def test_get_volt_offset(mock_inst, mock_inst_ask):
+    ch = channel.Channel(mock_inst)
+    result = ch.get_volt_offset(1)
+    assert result == 100.0 and type(result) is float
+
+def test_set_volt_offset(mock_inst):
+    ch = channel.Channel(mock_inst)
+    ch.set_volt_offset(1, 500)
+    mock_inst.write.assert_called_with(':CHAN1:OFFS 500')
+
+def test_auto_trigger(mock_inst):
+    ch = channel.Channel(mock_inst)
+    ch.auto_trigger(1)
+    calls = [call(':TRIG:SOUR CHAN1'), call(':TRIG:LEV:ASET')]
+    mock_inst.write.assert_has_calls(calls, any_order=False)
+
+def test_set_trigger(mock_inst, mock_inst_ask):
+    ch = channel.Channel(mock_inst)
+    ch.set_trigger(1, 50)
+    calls = [call(':TRIG:SOUR CHAN1'), call(':TRIG:LEV 50')]
+    mock_inst.write.assert_has_calls(calls, any_order=False)
+    
+def test_get_vpp(mock_inst, mock_inst_ask):
+    ch = channel.Channel(mock_inst)
+    result = ch.get_vpp(1)
+    assert result == 100.0 and type(result) is float
+    
+def test_get_vrms(mock_inst, mock_inst_ask):
+    ch = channel.Channel(mock_inst)
+    result = ch.get_vrms(1)
+    assert result == 100.0 and type(result) is float
+    
+def test_get_frequency(mock_inst, mock_inst_ask):
+    ch = channel.Channel(mock_inst)
+    result = ch.get_frequency(1)
+    assert result == 100.0 and type(result) is float
+    
+def test_get_period(mock_inst, mock_inst_ask):
+    ch = channel.Channel(mock_inst)
+    result = ch.get_period(1)
+    assert result == 100.0 and type(result) is float
+    
+def test_get_phase(mock_inst, mock_inst_ask):
+    ch = channel.Channel(mock_inst)
+    result = ch.get_phase(1, 2)
+    assert result == 100.0 and type(result) is float
+
+def test_set_coupling_ac(mock_inst):
+    ch = channel.Channel(mock_inst)
+    ch.set_coupling(1, "AC")
+    mock_inst.write.assert_called_with(':CHAN1:COUP AC')
+
+def test_set_coupling_dc(mock_inst):
+    ch = channel.Channel(mock_inst)
+    ch.set_coupling(1, "DC")
+    mock_inst.write.assert_called_with(':CHAN1:COUP DC')
+
+def test_toggle_channel_off(mock_inst, mock_inst_ask_true):
+    ch = channel.Channel(mock_inst)
+    ch.toggle_channel(1)
+    mock_inst.write.assert_called_with('CHAN1:DISP OFF')
+
+def test_toggle_channel_on(mock_inst, mock_inst_ask_false):
+    ch = channel.Channel(mock_inst)
+    ch.toggle_channel(1)
+    mock_inst.write.assert_called_with('CHAN1:DISP ON')

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -1,0 +1,35 @@
+import pytest
+from pytest_mock import mocker
+import usbtmc
+from src.oscilloscopy import channel
+
+@pytest.fixture
+def mock_inst(mocker):
+    mock = mocker.patch('usbtmc.Instrument')
+    return mock
+
+@pytest.fixture
+def mock_inst_ask(mocker):
+    mock = mocker.patch('usbtmc.Instrument.ask')
+    mock.return_value = 100
+    return mock
+
+def test_get_time_scale(mock_inst, mock_inst_ask):
+    ch = channel.Channel(mock_inst)
+    result = ch.get_time_scale()
+    assert result == 100 and type(result) is float
+ 
+def test_set_time_scale(mock_inst, mock_inst_ask):
+    ch = channel.Channel(mock_inst)
+    ch.set_time_scale(120)
+    mock_inst.write.assert_called_with(':TIM:SCAL 120')
+
+def test_get_time_delay(mock_inst, mock_inst_ask):
+    ch = channel.Channel(mock_inst)
+    result = ch.get_time_delay()
+    assert result == 100.0 and type(result) is float
+ 
+def test_set_time_delay(mock_inst, mock_inst_ask):
+    ch = channel.Channel(mock_inst)
+    ch.set_time_delay(120)
+    mock_inst.write.assert_called_with(':TIM:POS 120')

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,53 @@
+import pytest
+from pytest_mock import mocker
+import usbtmc
+from src.oscilloscopy import generator
+
+@pytest.fixture
+def mock_inst(mocker):
+    mock = mocker.patch('usbtmc.Instrument')
+    return mock
+
+def test_sin(mock_inst):
+    gen = generator.Generator(mock_inst)
+    gen.sin(amp=2.0, freq=13000, offs=0.5)
+    mock_inst.write.assert_called_with(
+        'WGEN:FUNC SIN;FREQ 13000;VOLT 2.0;VOLT:OFFS 0.5')
+
+def test_square(mock_inst):
+    gen = generator.Generator(mock_inst)
+    gen.square(amp=2.0, freq=13000, duty_cycle=60.0, offs=0.5)
+    mock_inst.write.assert_called_with(
+        'WGEN:FUNC SQU;FREQ 13000;VOLT 2.0;VOLT:OFFS 0.5;:WGEN:FUNC:SQU:DCYC 60.0')
+
+def test_ramp(mock_inst):
+    gen = generator.Generator(mock_inst)
+    gen.ramp(amp=2.0, freq=13000, symmetry=60.0, offs=0.5)
+    mock_inst.write.assert_called_with(
+        'WGEN:FUNC RAMP;FREQ 13000;VOLT 2.0;VOLT:OFFS 0.5;:WGEN:FUNC:RAMP:SYMM 60.0')
+
+def test_pulse(mock_inst):
+    gen = generator.Generator(mock_inst)
+    gen.pulse(amp=2.0, freq=13000, width=20, offs=0.5)
+    mock_inst.write.assert_called_with(
+        'WGEN:FUNC PULS;FREQ 13000;VOLT:HIGH 2.0;VOLT:LOW 0.5;:WGEN:FUNC:PULS:WIDT 20')
+
+def test_dc(mock_inst):
+    gen = generator.Generator(mock_inst)
+    gen.dc(amp=2.0)
+    mock_inst.write.assert_called_with("WGEN:FUNC DC;VOLT:OFFS 2.0")
+
+def test_noise(mock_inst):
+    gen = generator.Generator(mock_inst)
+    gen.noise(amp=2.0, offs=0.5)
+    mock_inst.write.assert_called_with("WGEN:FUNC NOIS;VOLT 2.0;VOLT:OFFS 0.5")
+
+def test_on(mock_inst):
+    gen = generator.Generator(mock_inst)
+    gen.on()
+    mock_inst.write.assert_called_with("WGEN:OUTP ON")
+
+def test_off(mock_inst):
+    gen = generator.Generator(mock_inst)
+    gen.off()
+    mock_inst.write.assert_called_with("WGEN:OUTP OFF")

--- a/tests/test_oscilloscope.py
+++ b/tests/test_oscilloscope.py
@@ -1,0 +1,39 @@
+import pytest
+from pytest_mock import mocker
+import usbtmc
+from src.oscilloscopy import oscilloscope
+
+@pytest.fixture
+def mock_inst(mocker):
+    mock = mocker.patch('usbtmc.Instrument')
+    return mock
+
+def test_reset(mock_inst):
+    osc = oscilloscope.Oscilloscope(mock_inst)
+    osc.reset()
+    mock_inst.write.assert_called_with(":RST")
+
+def test_stop(mock_inst):
+    osc = oscilloscope.Oscilloscope(mock_inst)
+    osc.stop()
+    mock_inst.write.assert_called_with(":STOP")
+
+def test_run(mock_inst):
+    osc = oscilloscope.Oscilloscope(mock_inst)
+    osc.run()
+    mock_inst.write.assert_called_with(":RUN")
+
+def test_single(mock_inst):
+    osc = oscilloscope.Oscilloscope(mock_inst)
+    osc.single()
+    mock_inst.write.assert_called_with(":SINGLE")
+
+def test_auto_scale(mock_inst):
+    osc = oscilloscope.Oscilloscope(mock_inst)
+    osc.auto_scale()
+    mock_inst.write.assert_called_with(":AUT")
+
+def test_set_acquire(mock_inst):
+    osc = oscilloscope.Oscilloscope(mock_inst)
+    osc.set_acquire('normal')
+    mock_inst.write.assert_called_with(":ACQ:TYPE NORMAL")


### PR DESCRIPTION
Finally releasing the first stable version of OscilloscoPy!

This PR:
- Add Unit Tests for the three main classes methods: Channel, Generator and Oscilloscope.

TODOS before release:
- Workaround for list_resources (change installation on poetry or modifying oscilloscopy.py
- Channel refactor (?)
- Add type notations
- Remove numpy